### PR TITLE
Add delay to make sure the keyboard shows on login

### DIFF
--- a/app/src/main/java/com/lukaszgajos/keepassmob/LoginActivity.java
+++ b/app/src/main/java/com/lukaszgajos/keepassmob/LoginActivity.java
@@ -128,8 +128,13 @@ public class LoginActivity extends AppCompatActivity implements View.OnClickList
         if (lastDbUri.length() > 0){
             setDbUri(Uri.parse(lastDbUri));
             if(mPassword.requestFocus()) {
-                InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
-                imm.showSoftInput(mPassword, InputMethodManager.SHOW_IMPLICIT);
+                mPassword.postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+                        imm.showSoftInput(mPassword, InputMethodManager.SHOW_IMPLICIT);
+                    }
+                }, 300);
             }
         }
 
@@ -161,6 +166,15 @@ public class LoginActivity extends AppCompatActivity implements View.OnClickList
         Uri fromFileSystemDb = getIntent().getData();
         if (fromFileSystemDb != null){
             setDbUri(fromFileSystemDb);
+            if(mPassword.requestFocus()) {
+                mPassword.postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+                        imm.showSoftInput(mPassword, InputMethodManager.SHOW_IMPLICIT);
+                    }
+                }, 300);
+            }
         } else {
             checkIfSessionActive();
         }


### PR DESCRIPTION
They keyboard was not showing on initial launch without adding a short delay on the focus of the password field, if a password database was already set.  This fixes it.